### PR TITLE
Clarified support for class commons, which TexMate does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@ Atlas importer is designed to use the corona exporter from texture packer. It ke
 
 Texture packer automatically combines unique frames but keeps references, and preserves offset data after automatic trimming.
 
-Texmate is made supporting class commons and requires a class library. https://github.com/bartbes/Class-Commons
+Texmate requires a specific class library, [middleclass](https://github.com/bartbes/Class-Commons), to be on the `packages.path`. Supporting for [class commons](https://github.com/bartbes/Class-Commons) is planned for a later release.
 
 ## Usage
 
 ```lua
---Class commons library
-class = require("middleclass")
-
 AtlasImporter = require("AtlasImporter")
 TexMate = require("TexMate")
 
@@ -24,7 +21,7 @@ function love.load ()
     --myAtlas = AtlasImporter.loadAtlasShoeBox("ASSETS/sprites","ASSETS/sprites.png")
     myAtlas = AtlasImporter.loadAtlasTexturePacker("ASSETS/spriteTP2","ASSETS/spriteTP.png")
 
-    -- use the exporter marked Corona TM SDK from texture packer. 
+    -- use the exporter marked Corona TM SDK from texture packer.
     -- If using shoebox, use the settings file provided
 
     animlist = {}

--- a/TexMate.lua
+++ b/TexMate.lua
@@ -1,4 +1,6 @@
-local _M = CLASS("texmate")
+local class = require('middleclass')
+
+local _M = class("texmate")
 --pass in the atlas, and it will make a deck, and preseve offset data.
 --framerate, works as a global number
 

--- a/TexMateStatic.lua
+++ b/TexMateStatic.lua
@@ -1,4 +1,6 @@
-local _M = CLASS("texmate")
+local class = require('middleclass')
+
+local _M = class("texmate")
 --pass in the atlas, and it will make a deck, and preseve offset data.
 --framerate, works as a global number
 


### PR DESCRIPTION
At least, not in an acceptable way.

Removed the dependency on a magic `CLASS` global variable to exist.
We will later refactor TexMate to support class commons by making it an interface to a class instead of a constructor.
